### PR TITLE
Fix indentBlock command on lists

### DIFF
--- a/src/indentblockcommand.js
+++ b/src/indentblockcommand.js
@@ -70,24 +70,34 @@ export default class IndentBlockCommand extends Command {
 	 */
 	execute() {
 		const model = this.editor.model;
-		const doc = model.document;
 
-		const itemsToChange = Array.from( doc.selection.getSelectedBlocks() );
+		const blocksToChange = getBlocksToChange( model );
 
 		model.change( writer => {
-			for ( const item of itemsToChange ) {
-				const currentIndent = item.getAttribute( 'blockIndent' );
+			for ( const block of blocksToChange ) {
+				const currentIndent = block.getAttribute( 'blockIndent' );
 
 				const nextIndent = this._indentBehavior.getNextIndent( currentIndent );
 
 				if ( nextIndent ) {
-					writer.setAttribute( 'blockIndent', nextIndent, item );
+					writer.setAttribute( 'blockIndent', nextIndent, block );
 				} else {
-					writer.removeAttribute( 'blockIndent', item );
+					writer.removeAttribute( 'blockIndent', block );
 				}
 			}
 		} );
 	}
+}
+
+// Returns blocks from selection that should have blockIndent selection set.
+//
+// @param {module:engine/model/model~model} model A model.
+function getBlocksToChange( model ) {
+	const selection = model.document.selection;
+	const schema = model.schema;
+	const blocksInSelection = Array.from( selection.getSelectedBlocks() );
+
+	return blocksInSelection.filter( block => schema.checkAttribute( block, 'blockIndent' ) );
 }
 
 /**

--- a/tests/indentblockcommand.js
+++ b/tests/indentblockcommand.js
@@ -34,6 +34,41 @@ describe( 'IndentBlockCommand', () => {
 		return editor.destroy();
 	} );
 
+	describe( 'common behavior', () => {
+		let indentBehavior;
+
+		beforeEach( () => {
+			indentBehavior = {
+				checkEnabled: sinon.stub().returns( true ),
+				getNextIndent: sinon.stub()
+			};
+
+			command = new IndentBlockCommand( editor, indentBehavior );
+		} );
+
+		describe( 'execute()', () => {
+			it( 'should be executed for all selected blocks', () => {
+				setData( model,
+					'<paragraph>f[oo</paragraph>' +
+					'<paragraph>foo</paragraph>' +
+					'<paragraph>f]oo</paragraph>'
+				);
+				command.execute();
+				sinon.assert.calledThrice( indentBehavior.getNextIndent );
+			} );
+
+			it( 'should be executed only for blocks that can have indentBlock attribute', () => {
+				setData( model,
+					'<paragraph>f[oo</paragraph>' +
+					'<block>foo</block>' +
+					'<paragraph>f]oo</paragraph>'
+				);
+				command.execute();
+				sinon.assert.calledTwice( indentBehavior.getNextIndent );
+			} );
+		} );
+	} );
+
 	describe( 'indent', () => {
 		describe( 'using classes', () => {
 			beforeEach( () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The 'indentBlock' command should be executed on blocks from a selection according to schema rules. Closes ckeditor/ckeditor5#2347.

---

### Additional information
