### PR TITLE
T/11:  Fix indent block command on nested blocks.

### DIFF
--- a/src/indentblockcommand.js
+++ b/src/indentblockcommand.js
@@ -53,7 +53,7 @@ export default class IndentBlockCommand extends Command {
 		const editor = this.editor;
 		const model = editor.model;
 
-		const block = first( model.document.selection.getSelectedBlocks() );
+		const block = first( model.document.selection.getTopMostBlocks() );
 
 		// If selection is not in a list item, the command is disabled.
 		if ( !block || !model.schema.checkAttribute( block, 'blockIndent' ) ) {
@@ -95,7 +95,7 @@ export default class IndentBlockCommand extends Command {
 function getBlocksToChange( model ) {
 	const selection = model.document.selection;
 	const schema = model.schema;
-	const blocksInSelection = Array.from( selection.getSelectedBlocks() );
+	const blocksInSelection = Array.from( selection.getTopMostBlocks() );
 
 	return blocksInSelection.filter( block => schema.checkAttribute( block, 'blockIndent' ) );
 }

--- a/src/indentblockcommand.js
+++ b/src/indentblockcommand.js
@@ -55,7 +55,6 @@ export default class IndentBlockCommand extends Command {
 
 		const block = first( model.document.selection.getTopMostBlocks() );
 
-		// If selection is not in a list item, the command is disabled.
 		if ( !block || !model.schema.checkAttribute( block, 'blockIndent' ) ) {
 			this.isEnabled = false;
 

--- a/tests/indentblockcommand.js
+++ b/tests/indentblockcommand.js
@@ -58,7 +58,7 @@ describe( 'IndentBlockCommand', () => {
 		} );
 
 		describe( 'refresh()', () => {
-			it( 'should not call indentBehavior.checkEnabled() for a selected block', () => {
+			it( 'should not call indentBehavior.checkEnabled() for a selected block that cannot have indentBlock attribute', () => {
 				setData( model, '[<parentBlock><paragraph>foo</paragraph></parentBlock>]' );
 				command.refresh();
 				sinon.assert.notCalled( indentBehavior.checkEnabled );

--- a/tests/indentblockcommand.js
+++ b/tests/indentblockcommand.js
@@ -146,6 +146,20 @@ describe( 'IndentBlockCommand', () => {
 					command.execute();
 					expect( getData( model ) ).to.equal( '<paragraph blockIndent="indent-3">f[]oo</paragraph>' );
 				} );
+
+				it( 'should be executed only for top-most blocks that can have indentBlock attribute', () => {
+					setData( model,
+						'<paragraph>f[oo</paragraph>' +
+						'<parentBlock><paragraph>foo</paragraph><paragraph>foo</paragraph></parentBlock>' +
+						'<paragraph>f]oo</paragraph>'
+					);
+					command.execute();
+					expect( getData( model ) ).to.equal(
+						'<paragraph blockIndent="indent-1">f[oo</paragraph>' +
+						'<parentBlock><paragraph>foo</paragraph><paragraph>foo</paragraph></parentBlock>' +
+						'<paragraph blockIndent="indent-1">f]oo</paragraph>'
+					);
+				} );
 			} );
 		} );
 

--- a/tests/indentblockcommand.js
+++ b/tests/indentblockcommand.js
@@ -58,7 +58,7 @@ describe( 'IndentBlockCommand', () => {
 		} );
 
 		describe( 'refresh()', () => {
-			it( 'should be executed for a top-most selected block', () => {
+			it( 'should not call indentBehavior.checkEnabled() for a selected block', () => {
 				setData( model, '[<parentBlock><paragraph>foo</paragraph></parentBlock>]' );
 				command.refresh();
 				sinon.assert.notCalled( indentBehavior.checkEnabled );

--- a/tests/indentblockcommand.js
+++ b/tests/indentblockcommand.js
@@ -58,10 +58,10 @@ describe( 'IndentBlockCommand', () => {
 		} );
 
 		describe( 'refresh()', () => {
-			it( 'should not call indentBehavior.checkEnabled() for a selected block that cannot have indentBlock attribute', () => {
+			it( 'should be disabled if a top-most block disallows indentBlock attribute', () => {
 				setData( model, '[<parentBlock><paragraph>foo</paragraph></parentBlock>]' );
 				command.refresh();
-				sinon.assert.notCalled( indentBehavior.checkEnabled );
+				expect( command.isEnabled ).to.be.false;
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The 'indentBlock' command will operate on top-most blocks. Closes ckeditor/ckeditor5#2348.

---

### Additional information

* It's done from branch `t/8` so the #14 PR must be resolved first and then this must be rebased on master.
