### PR TITLE
Make IndentBlock work regardless of editor plugins order.

### DIFF
--- a/src/indentblock.js
+++ b/src/indentblock.js
@@ -46,10 +46,9 @@ export default class IndentBlock extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	init() {
+	afterInit() {
 		const editor = this.editor;
 		const schema = editor.model.schema;
-		const conversion = editor.conversion;
 		const configuration = editor.config.get( 'indentBlock' );
 
 		// Enable block indentation by default in paragraph and default headings.
@@ -67,7 +66,7 @@ export default class IndentBlock extends Plugin {
 		const outdentConfig = Object.assign( { direction: 'backward' }, configuration );
 
 		if ( useOffsetConfig ) {
-			this._setupConversionUsingOffset( conversion );
+			this._setupConversionUsingOffset( editor.conversion );
 			editor.commands.add( 'indentBlock', new IndentBlockCommand( editor, new IndentUsingOffset( indentConfig ) ) );
 			editor.commands.add( 'outdentBlock', new IndentBlockCommand( editor, new IndentUsingOffset( outdentConfig ) ) );
 		} else {
@@ -75,13 +74,7 @@ export default class IndentBlock extends Plugin {
 			editor.commands.add( 'indentBlock', new IndentBlockCommand( editor, new IndentUsingClasses( indentConfig ) ) );
 			editor.commands.add( 'outdentBlock', new IndentBlockCommand( editor, new IndentUsingClasses( outdentConfig ) ) );
 		}
-	}
 
-	/**
-	 * @inheritDoc
-	 */
-	afterInit() {
-		const editor = this.editor;
 		const indentCommand = editor.commands.get( 'indent' );
 		const outdentCommand = editor.commands.get( 'outdent' );
 

--- a/tests/indentblock-integration.js
+++ b/tests/indentblock-integration.js
@@ -13,7 +13,7 @@ import IndentEditing from '../src/indentediting';
 import IndentBlock from '../src/indentblock';
 
 describe( 'IndentBlock - integration', () => {
-	let editor, model, doc;
+	let editor, doc;
 
 	testUtils.createSinonSandbox();
 
@@ -28,8 +28,7 @@ describe( 'IndentBlock - integration', () => {
 			return createTestEditor( { indentBlock: { offset: 50, unit: 'px' } } )
 				.then( newEditor => {
 					editor = newEditor;
-					model = editor.model;
-					doc = model.document;
+					doc = editor.model.document;
 				} );
 		} );
 
@@ -54,8 +53,7 @@ describe( 'IndentBlock - integration', () => {
 				indentBlock: { offset: 50, unit: 'px' }
 			} ).then( newEditor => {
 				editor = newEditor;
-				model = editor.model;
-				doc = model.document;
+				doc = editor.model.document;
 			} );
 		} );
 
@@ -70,6 +68,22 @@ describe( 'IndentBlock - integration', () => {
 			expect( editor.getData() ).to.equal( '<p style="margin-left:50px;">foo</p>' );
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 				.to.equal( '<p style="margin-left:50px">foo</p>' );
+		} );
+	} );
+
+	it( 'should work with paragraph regardless of plugin order', () => {
+		return createTestEditor( {
+			plugins: [ IndentEditing, IndentBlock, Paragraph, HeadingEditing ],
+			indentBlock: { offset: 50, unit: 'px' }
+		} ).then( newEditor => {
+			editor = newEditor;
+			doc = editor.model.document;
+
+			editor.setData( '<p style="margin-left:50px">foo</p>' );
+
+			const paragraph = doc.getRoot().getChild( 0 );
+
+			expect( paragraph.hasAttribute( 'blockIndent' ) ).to.be.true;
 		} );
 	} );
 

--- a/tests/indentblock-integration.js
+++ b/tests/indentblock-integration.js
@@ -71,7 +71,8 @@ describe( 'IndentBlock - integration', () => {
 		} );
 	} );
 
-	it( 'should work with paragraph regardless of plugin order', () => {
+	// https://github.com/ckeditor/ckeditor5/issues/2359
+	it( 'should work with paragraphs regardless of plugin order', () => {
 		return createTestEditor( {
 			plugins: [ IndentEditing, IndentBlock, Paragraph, HeadingEditing ],
 			indentBlock: { offset: 50, unit: 'px' }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Make IndentBlock work regardless of editor plugins order. Closes ckeditor/ckeditor5#2359.

--- 

Checking schema for registered elements should be done
in afterInit call to prevent plugin ordering related bugs.