### PR TITLE
I/3287: Align code to styles normalization

### DIFF
--- a/src/indentblock.js
+++ b/src/indentblock.js
@@ -99,17 +99,18 @@ export default class IndentBlock extends Plugin {
 		const locale = this.editor.locale;
 		const marginProperty = locale.contentLanguageDirection === 'rtl' ? 'margin-right' : 'margin-left';
 
-		conversion.for( 'upcast' ).attributeToAttribute( {
-			view: {
-				styles: {
-					[ marginProperty ]: /[\s\S]+/
-				}
-			},
-			model: {
-				key: 'blockIndent',
-				value: viewElement => viewElement.getStyle( marginProperty )
-			}
-		} );
+		// TODO: breaks something..
+		// conversion.for( 'upcast' ).attributeToAttribute( {
+		// 	view: {
+		// 		styles: {
+		// 			[ marginProperty ]: /[\s\S]+/
+		// 		}
+		// 	},
+		// 	model: {
+		// 		key: 'blockIndent',
+		// 		value: viewElement => viewElement.getStyle( marginProperty )
+		// 	}
+		// } );
 
 		// The margin shorthand should also work.
 		conversion.for( 'upcast' ).attributeToAttribute( {
@@ -120,7 +121,7 @@ export default class IndentBlock extends Plugin {
 			},
 			model: {
 				key: 'blockIndent',
-				value: viewElement => normalizeToMarginSideStyle( viewElement.getStyle( 'margin' ), marginProperty )
+				value: viewElement => viewElement.getStyle( marginProperty )
 			}
 		} );
 
@@ -162,46 +163,6 @@ export default class IndentBlock extends Plugin {
 
 		this.editor.conversion.attributeToAttribute( definition );
 	}
-}
-
-// Normalizes the margin shorthand value to the value of margin-left or margin-right CSS property.
-//
-// As such it will return:
-//
-// - '1em' -> '1em'
-// - '2px 1em' -> '1em'
-// - '2px 1em 3px' -> '1em'
-// - '2px 10px 3px 1em'
-//		-> '1em' (side "margin-left")
-//		-> '10px' (side "margin-right")
-//
-// @param {String} marginStyleValue Margin style value.
-// @param {String} side "margin-left" or "margin-right" depending on which margin should be returned.
-// @returns {String} Extracted value of margin-left or margin-right.
-function normalizeToMarginSideStyle( marginStyleValue, side ) {
-	// Splits the margin shorthand, ie margin: 2em 4em.
-	const marginEntries = marginStyleValue.split( ' ' );
-
-	let marginValue;
-
-	// If only one value defined, ie: `margin: 1px`.
-	marginValue = marginEntries[ 0 ];
-
-	// If only two values defined, ie: `margin: 1px 2px`.
-	if ( marginEntries[ 1 ] ) {
-		marginValue = marginEntries[ 1 ];
-	}
-
-	// If four values defined, ie: `margin: 1px 2px 3px 4px`.
-	if ( marginEntries[ 3 ] ) {
-		if ( side === 'margin-left' ) {
-			marginValue = marginEntries[ 3 ];
-		} else {
-			marginValue = marginEntries[ 1 ];
-		}
-	}
-
-	return marginValue;
 }
 
 /**

--- a/src/indentblock.js
+++ b/src/indentblock.js
@@ -102,34 +102,17 @@ export default class IndentBlock extends Plugin {
 		const locale = this.editor.locale;
 		const marginProperty = locale.contentLanguageDirection === 'rtl' ? 'margin-right' : 'margin-left';
 
-		conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element', ( evt, data, conversionApi ) => {
-			const element = data.viewItem;
-
-			if ( !element.hasStyle( marginProperty ) ) {
-				return;
+		conversion.for( 'upcast' ).attributeToAttribute( {
+			view: {
+				styles: {
+					[ marginProperty ]: /[\s\S]+/
+				}
+			},
+			model: {
+				key: 'blockIndent',
+				value: viewElement => viewElement.getStyle( marginProperty )
 			}
-
-			// Try to consume appropriate values from consumable values list.
-			if ( !testStyle( marginProperty ) && !testStyle( 'margin' ) ) {
-				return;
-			}
-
-			if ( !data.modelRange ) {
-				data = Object.assign( data, conversionApi.convertChildren( data.viewItem, data.modelCursor ) );
-			}
-
-			const items = Array.from( data.modelRange.getItems() );
-			const node = items.shift();
-
-			if ( conversionApi.schema.checkAttribute( node, 'blockIndent' ) ) {
-				conversionApi.writer.setAttribute( 'blockIndent', element.getNormalizedStyle( marginProperty ), node );
-				conversionApi.consumable.consume( data.viewItem, { styles: marginProperty } );
-			}
-
-			function testStyle( styleName ) {
-				return conversionApi.consumable.test( data.viewItem, { styles: styleName } );
-			}
-		} ) );
+		} );
 
 		conversion.for( 'downcast' ).attributeToAttribute( {
 			model: 'blockIndent',

--- a/src/indentblock.js
+++ b/src/indentblock.js
@@ -99,24 +99,10 @@ export default class IndentBlock extends Plugin {
 		const locale = this.editor.locale;
 		const marginProperty = locale.contentLanguageDirection === 'rtl' ? 'margin-right' : 'margin-left';
 
-		// TODO: breaks something..
-		// conversion.for( 'upcast' ).attributeToAttribute( {
-		// 	view: {
-		// 		styles: {
-		// 			[ marginProperty ]: /[\s\S]+/
-		// 		}
-		// 	},
-		// 	model: {
-		// 		key: 'blockIndent',
-		// 		value: viewElement => viewElement.getStyle( marginProperty )
-		// 	}
-		// } );
-
-		// The margin shorthand should also work.
 		conversion.for( 'upcast' ).attributeToAttribute( {
 			view: {
 				styles: {
-					'margin': /[\s\S]+/
+					[ marginProperty ]: /[\s\S]+/
 				}
 			},
 			model: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Remove obsolete converter after introducing style normalization.

---

### Additional information

Sub-pr for: https://github.com/ckeditor/ckeditor5-engine/pull/1807.

This is the nice outcome of style normalization - the `margin` / `margin-left` is now handled by default conversion.

The code is only removed.
