### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/indentui.js
+++ b/src/indentui.js
@@ -68,7 +68,10 @@ export default class IndentUI extends Plugin {
 
 			view.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 
-			this.listenTo( view, 'execute', () => editor.execute( commandName ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( commandName );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
